### PR TITLE
Fix code scanning alert no. 66: Use of insecure SSL/TLS version

### DIFF
--- a/homeassistant/components/tcp/entity.py
+++ b/homeassistant/components/tcp/entity.py
@@ -54,6 +54,7 @@ class TcpEntity(Entity):
         self._ssl_context: ssl.SSLContext | None = None
         if self._config[CONF_SSL]:
             self._ssl_context = ssl.create_default_context()
+            self._ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
             if not self._config[CONF_VERIFY_SSL]:
                 self._ssl_context.check_hostname = False
                 self._ssl_context.verify_mode = ssl.CERT_NONE


### PR DESCRIPTION
Fixes [https://github.com/blastoise186/core/security/code-scanning/66](https://github.com/blastoise186/core/security/code-scanning/66)

To fix the problem, we need to ensure that the SSL context created by `ssl.create_default_context()` only allows secure versions of TLS (TLS 1.2 or higher). This can be achieved by setting the `minimum_version` attribute of the SSL context to `ssl.TLSVersion.TLSv1_2`. This change ensures that the context will not allow any connections using older, insecure versions of TLS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
