### PR TITLE
Fix code scanning alert no. 56: Clear-text logging of sensitive information

### DIFF
--- a/homeassistant/components/owntracks/messages.py
+++ b/homeassistant/components/owntracks/messages.py
@@ -172,7 +172,7 @@ def encrypt_message(secret, topic, message):
     try:
         message = message.encode("utf-8")
         payload = SecretBox(key).encrypt(message, encoder=Base64Encoder)
-        _LOGGER.debug("Encrypted message: %s to %s", message, payload)
+        _LOGGER.debug("Encrypted message to %s", payload)
         return payload.decode("utf-8")
     except ValueError:
         _LOGGER.warning("Unable to encrypt message for topic %s", topic)


### PR DESCRIPTION
Fixes [https://github.com/blastoise186/core/security/code-scanning/56](https://github.com/blastoise186/core/security/code-scanning/56)

To fix the problem, we need to ensure that sensitive data is not logged in clear text. Instead of logging the entire `message` variable, we can log a sanitized version of it that excludes sensitive information. This can be achieved by creating a function that removes or masks sensitive data before logging.

- Identify the lines where sensitive data is being logged.
- Create a function to sanitize the sensitive data.
- Replace the logging statements with calls to the sanitization function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
